### PR TITLE
check if biomart object is provided

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -255,7 +255,7 @@ cqn <- function(filtered_counts, biomart_results) {
 
     normalized_counts$E <- normalized_counts$y + normalized_counts$offset
 
-    normalized_counts
+    return(normalized_counts)
 
   }
 

--- a/R/functions.R
+++ b/R/functions.R
@@ -124,6 +124,7 @@ biomart_obj <- function(organism, host) {
 #'@param organism A character vector of the organism name. This argument
 #'takes partial strings. For example,"hsa" will match "hsapiens_gene_ensembl".
 get_biomart <- function(gene_ids, host, organism) {
+  if (is.null(config::get("biomart")$synID)) {
     id_type <- "ensembl_gene_id"
     ensembl <- biomart_obj(organism, host)
     message(paste0("Downloading sequence",
@@ -161,6 +162,18 @@ get_biomart <- function(gene_ids, host, organism) {
       dplyr::filter(row_number(hgnc_symbol) == 1)
 
     biomart_results
+  } else {
+    biomart_results <- get_data(config::get("biomart")$synID,
+             config::get("biomart")$version)
+    required_variables <- c("gene_length", "percentage_gene_gc_content")
+    if (!(required_variables %in% colnames(biomart_results))) {
+      vars <- glue::glue_collapse(setdiff(required_variables, colnames(biomart_results)),
+                                  sep = ", ",
+                                  last = " and ")
+      message(glue::glue("Warning: {vars} missing from biomart object. This information is required for Conditional Quantile Normalization"))
+    }
+    biomart_results
+  }
 }
 #'Filter genes
 #'
@@ -206,21 +219,42 @@ convert_geneids <- function(count_df) {
 #' Conditional Quantile Normalization (CQN)
 #'
 #' Normalize counts by CQN. By providing a biomart object, the systematic effect of GC content
-#' is removed and gene length (in bp) variation is accounted for.
+#' is removed and gene length (in bp) variation is accounted for. Genes with missing GC content
+#' or gene lengths will be removed from the counts matrix.
 #'
 #' @param filtered_counts
 #' @param biomart_results
 #'
 cqn <- function(filtered_counts, biomart_results) {
-  normalized_counts <- cqn::cqn(filtered_counts$filteredExprMatrix$counts,
-                                x = biomart_results[biomart_results$ensembl_gene_id %in%
-                                                      filtered_counts$filteredExprMatrix$genes$ensembl_gene_id,
-                                                    "percentage_gene_gc_content"],
-                                lengths = biomart_results[biomart_results$ensembl_gene_id %in%
-                                                            filtered_counts$filteredExprMatrix$genes$ensembl_gene_id,
-                                                          "gene_length"],
-                                lengthMethod = "smooth",
-                                verbose = FALSE
-                                )
-  normalized_counts$E <- normalized_counts$y + normalized_counts$offset
+
+  required_variables <- c("gene_length", "percentage_gene_gc_content")
+
+  if (!all(required_variables %in% colnames(biomart_results))) {
+    message(glue::glue("Error:{setdiff(required_variables,
+                       colnames(biomart_results))} missing from
+                       biomart object. This information is required
+                       for Conditional Quantile Normalization"))
+  } else {
+
+    counts <- filtered_counts$filteredExprMatrix$counts
+
+    genes_to_analyze <- intersect(rownames(counts), biomart_results$ensembl_gene_id)
+
+    to_normalize <- subset(counts, rownames(counts) %in% genes_to_analyze)
+    gc_length <- subset(biomart_results, biomart_results$ensembl_gene_id %in% genes_to_analyze)
+
+    normalized_counts <- cqn::cqn(to_normalize,
+                                  x = gc_length[, "percentage_gene_gc_content"],
+                                  lengths = gc_length[, "gene_length"],
+                                  lengthMethod = "smooth",
+                                  verbose = FALSE
+    )
+
+    normalized_counts$E <- normalized_counts$y + normalized_counts$offset
+
+    normalized_counts
+
+  }
+
+
 }

--- a/R/functions.R
+++ b/R/functions.R
@@ -175,7 +175,7 @@ get_biomart <- function(gene_ids, host, organism) {
                          This information is required for Conditional
                          Quantile Normalization"))
     }
-    biomart_results
+    return(biomart_results)
   }
 }
 #'Filter genes

--- a/config.yml
+++ b/config.yml
@@ -5,6 +5,9 @@ default:
   metadata:
     synID: syn21587404
     version: 3
+  biomart:
+    synID: syn21907998
+    version:
   factors:
   continuous:
   sample:
@@ -15,6 +18,9 @@ mayo:
   metadata:
     synID: syn21587404
     version: 4
+  biomart:
+    synID: syn21907998
+    version:
   factors: [ "donorid", "sampleid", "source", "sex", "flowcell", "diagnosis", "source_tissue_diagnosis", "tissue_diagnosis", "tissue_APOE4" ]
   continuous: [ "rin", "rin2", "age_death", "pct_pf_reads_aligned",
                 "pct_coding_bases", "pct_intergenic_bases", "pct_intronic_bases",


### PR DESCRIPTION
To unblock not being able to query Ensembl via biomaRt, this PR: 

- Checks if a synID was provided to a Ensembl data frame and if yes, downloads it. If not, biomaRt is queried.
- Example Ensembl data frame added to the default config file.
- required parameters are gene length and percent gc content, as these are required for CQN normalization. A warning is returned if the Ensembl data frame downloaded is missing these variables. 
- Modified CQN input objects to be the intersection of gene ids in the counts matrix and biomaRt object. 

Fixes #26 