### PR TITLE
Improve get_biomart and related functions 

### DIFF
--- a/R/plan.R
+++ b/R/plan.R
@@ -7,8 +7,13 @@ plan <- drake_plan(
   clean_md = clean_covariates(md = import_metadata, factors = config::get("factors"),
                               continuous = config::get("continuous")),
   #covar_correlation = CovariateAnalysis::getAssociationStatistics(clean_md, PVAL = 0.05),
-  geneids = convert_geneids(count_df = counts),
-  biomart_results = get_biomart(geneids$ensembl_gene_id, host = "ensembl.org", organism = "hsa"),# Ensembl Release 99 (January 2020)
+  biomart_results = get_biomart(count_df = counts,
+                                gene_id = config::get("biomart")$`gene id`,
+                                synid = config::get("biomart")$synID,
+                                version = config::get("biomart")$version,
+                                filters = config::get("biomart")$filters,
+                                host = config::get("biomart")$host,
+                                organism = config::get("biomart")$organism),
   filtered_counts = filter_genes(md = clean_md, count_df = counts),
   cqn_counts = cqn(filtered_counts, biomart_results)
 )

--- a/config.yml
+++ b/config.yml
@@ -10,6 +10,9 @@ default:
   biomart:
     synID: syn21907998
     version:
+    gene id:
+    host: ensembl.org
+    organism: hsa
   factors:
   continuous:
 mayo:
@@ -25,6 +28,9 @@ mayo:
     synID:
     version:
     gene id: ensembl_gene_id
+    filters: ensembl_gene_id
+    host: ensembl.org # Ensembl Release 99 (January 2020)
+    organism: hsa
   factors: [ "donorid", "sampleid", "source", "sex", "flowcell", "diagnosis", "source_tissue_diagnosis", "tissue_diagnosis", "tissue_APOE4" ]
   continuous: [ "rin", "rin2", "age_death", "pct_pf_reads_aligned",
                 "pct_coding_bases", "pct_intergenic_bases", "pct_intronic_bases",


### PR DESCRIPTION
This PR fixes #23, fixes #9, fixes #34

Changes to `get_biomart()`:

- Improves syntax as config parameters are called as function arguments instead of being embedded in the function itself (difficult to debug)
- Collapses duplicate Ensembl Ids that arise from multiple HGCN symbols. HGNC symbols are put in a comma separated list.
- Makes less assumptions - options are configurable from `config.yml`, i.e. `filters`
- `biomaRt::getBM()`contains a parameter `useCache` that defaults to `TRUE`. This code fix sets the default to `FALSE`. The `biomaRt`function documentation did not make it clear how this cache works. I'm concerned analyzing different datasets in the same R environment would cause Ensembl queries to become out of sync as the biomart object created is very specific to each dataset - it is populated from the IDs contained in the counts matrix.
- Returns a biomart object with gene Ids as rownames

Changes to `convert_geneids`:

- simplifies output to character vector list. 
- removes pattern matching that was not robust. Need to address "cleaning" the counts (i.e. remove N_mapped etc.) in an earlier step. Issue documented in #33. 