### PR TITLE
Fix global variables 

### DIFF
--- a/R/plan.R
+++ b/R/plan.R
@@ -17,6 +17,7 @@
 #' @param biomart_id Synapse ID to biomart object.
 #' @param biomart_version Optionally, include Synapse file version number.
 #' @inheritParams get_biomart
+#' @inheritParams filter_genes
 #' @export
 rnaseq_plan <- function(metadata_id, metadata_version, counts_id,
                         counts_version, gene_id_input, factor_input,

--- a/R/plan.R
+++ b/R/plan.R
@@ -22,7 +22,7 @@ rnaseq_plan <- function(metadata_id, metadata_version, counts_id,
                         counts_version, gene_id_input, factor_input,
                         continuous_input, gene_id,
                         biomart_id, biomart_version, host, filters,
-                        organism){
+                        organism, conditions){
   drake::drake_plan(
     import_metadata = get_data(!!metadata_id,
                                !!metadata_version),
@@ -41,7 +41,8 @@ rnaseq_plan <- function(metadata_id, metadata_version, counts_id,
                                 host = !!host,
                                 organism = !!organism),
     filtered_counts = filter_genes(md = clean_md,
-                                   count_df = counts),
+                                   count_df = counts,
+                                   conditions = !!conditions),
     cqn_counts = cqn(filtered_counts,
                      biomart_results)
 )

--- a/config.yml
+++ b/config.yml
@@ -16,6 +16,7 @@ default:
     organism: hsa
   factors:
   continuous:
+  conditions: diagnosis, sex
 mayo:
   counts:
     synID: syn21587392

--- a/man/collapse_duplicate_hgnc_symbol.Rd
+++ b/man/collapse_duplicate_hgnc_symbol.Rd
@@ -7,7 +7,7 @@
 collapse_duplicate_hgnc_symbol(biomart_results)
 }
 \arguments{
-\item{biomart_results}{Output of `get_biomart()`}
+\item{biomart_results}{Output of \code{"sageseqr::get_biomart()"}.}
 }
 \description{
 Count normalization requires Ensembl Ids to be unique. In rare cases, there are more

--- a/man/cqn.Rd
+++ b/man/cqn.Rd
@@ -9,7 +9,7 @@ cqn(filtered_counts, biomart_results)
 \arguments{
 \item{filtered_counts}{A counts data frame with genes removed that have low expression.}
 
-\item{biomart_results}{Output of `get_biomart()`}
+\item{biomart_results}{Output of \code{"sageseqr::get_biomart()"}.}
 }
 \description{
 Normalize counts by CQN. By providing a biomart object, the systematic effect of GC content

--- a/man/filter_genes.Rd
+++ b/man/filter_genes.Rd
@@ -4,12 +4,14 @@
 \alias{filter_genes}
 \title{Filter genes}
 \usage{
-filter_genes(md, count_df)
+filter_genes(md, count_df, conditions)
 }
 \arguments{
 \item{md}{A data frame with sample identifiers in a column and relevant experimental covariates.}
 
 \item{count_df}{A counts data frame with sample identifiers as rownames.}
+
+\item{conditions}{Conditions to bin gene counts that correspond to variables in `md`.}
 }
 \description{
 Remove genes that have less than 1 counts per million (cpm) in at least 50%

--- a/man/rnaseq_plan.Rd
+++ b/man/rnaseq_plan.Rd
@@ -56,6 +56,8 @@ This specification is highly recommended for a reproducible workflow.
 
 \item{organism}{A character vector of the organism name. This argument
 takes partial strings. For example,"hsa" will match "hsapiens_gene_ensembl".}
+
+\item{conditions}{Conditions to bin gene counts that correspond to variables in `md`.}
 }
 \description{
 This function wraps the \code{"drake::plan()"}.

--- a/man/rnaseq_plan.Rd
+++ b/man/rnaseq_plan.Rd
@@ -17,7 +17,8 @@ rnaseq_plan(
   biomart_version,
   host,
   filters,
-  organism
+  organism,
+  conditions
 )
 }
 \arguments{

--- a/tests/testthat/test-boxplot_vars.R
+++ b/tests/testthat/test-boxplot_vars.R
@@ -1,0 +1,10 @@
+test_that("output is plot", {
+  metadata <- tibble::tribble(~diagnosis, ~ageofdeath, ~pmi,
+                              "CT", 60, 4,
+                              "CT", 61, 5,
+                              "ZZ", 50, 4)
+  output <- boxplot_vars(metadata,
+                         include_vars = c("pmi", "ageofdeath"),
+                         x_var = "diagnosis")
+  testthat::expect_equal(class(output), c("gg", "ggplot"))
+})

--- a/vignettes/customize-config.Rmd
+++ b/vignettes/customize-config.Rmd
@@ -30,5 +30,6 @@ biomart:
   version: Optionally, include Synapse file version number (e.g. 3).
   gene id: Column name that corresponds to the gene ids (e.g. ensembl_gene_id)
 factors: List of factor variables in brackets. Variables must be present in the metadata as column names (e.g. [ "donorid", "source"]).
-continuous: List of continuous variables in brackets. Variables must be present in the metadata as column names (e.g[ "rin", "rin2"]).
+continuous: List of continuous variables in brackets. Variables must be present in the metadata as column names (e.g. [ "rin", "rin2"]).
+conditions: Filtering low-expression genes is a common practice to improve sensitivity in detection of differentially expressed genes. Low count genes that have less than 1 counts per million (cpm) in 50% of the samples per the conditions provided here will be removed. (e.g. ["diagnosis", "sex"])
 ```

--- a/vignettes/run-the-plan.Rmd
+++ b/vignettes/run-the-plan.Rmd
@@ -44,7 +44,8 @@ plan <- sageseqr::rnaseq_plan(metadata_id = config::get("metadata")$synID,
                     biomart_version = config::get("biomart")$version,
                     filters = config::get("biomart")$filters,
                     host = config::get("biomart")$host,
-                    organism = config::get("biomart")$organism
+                    organism = config::get("biomart")$organism, 
+                    conditions = config::get("conditions")
 )
 
 drake::make(plan)


### PR DESCRIPTION
Fixing the global variables required a full re-work of `sageseqr::filter_genes` and `sageseqr::boxplot_vars`. 

- Fixes #42 
- Fixes #3 
- Fixes #37
